### PR TITLE
feat: Add location information to lexed tokens and expand filter error messages to take advantage of it

### DIFF
--- a/src/filter/expr.rs
+++ b/src/filter/expr.rs
@@ -84,6 +84,8 @@ impl<'a, 'b> ExprVisitor<std::fmt::Result> for ExprPrinter<'a, 'b> {
 mod tests {
     use rstest::rstest;
 
+    use crate::filter::location::Loc;
+
     use super::*;
 
     #[rstest]
@@ -92,7 +94,7 @@ mod tests {
     #[case(
         Expr::Binary(
             Box::new(Expr::Literal("value".into())),
-            Token::In,
+            Token::In(Loc::new(1, 8)),
             Box::new(Expr::Property("test")),
         ),
         "(in \"value\" (property test))"
@@ -100,7 +102,7 @@ mod tests {
     #[case(
         Expr::Logical(
             Box::new(Expr::Literal("value".into())),
-            Token::And,
+            Token::And(Loc::new(1, 8)),
             Box::new(Expr::Property("test")),
         ),
         "(&& \"value\" (property test))"

--- a/src/filter/interpreter.rs
+++ b/src/filter/interpreter.rs
@@ -27,12 +27,12 @@ impl<'a, T: Filterable> ExprVisitor<FilterValue> for FilterContext<'a, T> {
         let left = self.visit_expr(left);
         let right = self.visit_expr(right);
         match operator {
-            Token::Equals => (left == right).into(),
-            Token::NotEquals => (left != right).into(),
-            Token::Contains => left.contains(&right).into(),
-            Token::In => right.contains(&left).into(),
-            Token::StartsWith => left.startswith(&right).into(),
-            Token::EndsWith => left.endswith(&right).into(),
+            Token::Equals(..) => (left == right).into(),
+            Token::NotEquals(..) => (left != right).into(),
+            Token::Contains(..) => left.contains(&right).into(),
+            Token::In(..) => right.contains(&left).into(),
+            Token::StartsWith(..) => left.startswith(&right).into(),
+            Token::EndsWith(..) => left.endswith(&right).into(),
             token => unreachable!("Encountered an unexpected binary operator '{token}'"),
         }
     }
@@ -41,10 +41,10 @@ impl<'a, T: Filterable> ExprVisitor<FilterValue> for FilterContext<'a, T> {
         let left = self.visit_expr(left);
 
         match operator {
-            Token::And if left.is_truthy() => self.visit_expr(right),
-            Token::And => false.into(),
-            Token::Or if !left.is_truthy() => self.visit_expr(right),
-            Token::Or => true.into(),
+            Token::And(..) if left.is_truthy() => self.visit_expr(right),
+            Token::And(..) => false.into(),
+            Token::Or(..) if !left.is_truthy() => self.visit_expr(right),
+            Token::Or(..) => true.into(),
             token => unreachable!("Encountered an unexpected logical operator '{token}'"),
         }
     }
@@ -53,7 +53,7 @@ impl<'a, T: Filterable> ExprVisitor<FilterValue> for FilterContext<'a, T> {
         let right = self.visit_expr(right);
 
         match operator {
-            Token::Not => {
+            Token::Not(..) => {
                 if right.is_truthy() {
                     false.into()
                 } else {

--- a/src/filter/lexer.rs
+++ b/src/filter/lexer.rs
@@ -23,7 +23,7 @@ impl<'a> Scanner<'a> {
         if let Some((idx, c)) = self.chars.peek() {
             if *c == '\n' {
                 self.line += 1;
-                self.line_start = *idx;
+                self.line_start = *idx + 1;
             }
 
             if *c == next {
@@ -40,7 +40,7 @@ impl<'a> Scanner<'a> {
         while let Some((idx, c)) = self.chars.peek() {
             if *c == '\n' {
                 self.line += 1;
-                self.line_start = *idx;
+                self.line_start = *idx + 1;
             }
 
             if !f(*idx, *c) {
@@ -60,7 +60,7 @@ impl<'a> Scanner<'a> {
             match c {
                 '\n' => {
                     self.line += 1;
-                    self.line_start = idx;
+                    self.line_start = idx + 1;
                 }
                 '"' => {
                     return Ok(Token::String(start_loc, &self.source[start + 1..idx]));
@@ -126,7 +126,7 @@ impl<'a> Iterator for Scanner<'a> {
                 ' ' | '\t' => {}
                 '\n' => {
                     self.line += 1;
-                    self.line_start = idx;
+                    self.line_start = idx + 1;
                 }
                 '(' => {
                     return Some(Ok(Token::LeftParen(Loc::new(
@@ -236,7 +236,7 @@ mod tests {
         $(
           match scanner.next() {
             Some(Ok($item)) => {},
-            Some(Ok(item)) => panic!("Expected '{}' but got '{}'", stringify!($item), item),
+            Some(Ok(item)) => panic!("Expected '{}' but got '{:?}'", stringify!($item), item),
             Some(Err(e)) => panic!("Error: {}", e),
             None => panic!("Expected '{}' but got the end of the parse sequence instead", stringify!($item)),
           }
@@ -336,6 +336,16 @@ mod tests {
             Token::And(..),
             Token::Not(..),
             Token::Property(.., "artifact.source-code"),
+        );
+    }
+
+    #[test]
+    fn test_location() {
+        assert_sequence!(
+            "true !=\nfalse",
+            Token::True(Loc { line: 1, column: 1 }),
+            Token::NotEquals(Loc { line: 1, column: 6 }),
+            Token::False(Loc { line: 2, column: 1 })
         );
     }
 }

--- a/src/filter/location.rs
+++ b/src/filter/location.rs
@@ -1,0 +1,19 @@
+use std::fmt::Display;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Hash, Default)]
+pub struct Loc {
+    line: usize,
+    column: usize,
+}
+
+impl Loc {
+    pub fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+}
+
+impl Display for Loc {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "line {}, column {}", self.line, self.column)
+    }
+}

--- a/src/filter/location.rs
+++ b/src/filter/location.rs
@@ -2,8 +2,8 @@ use std::fmt::Display;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Hash, Default)]
 pub struct Loc {
-    line: usize,
-    column: usize,
+    pub line: usize,
+    pub column: usize,
 }
 
 impl Loc {

--- a/src/filter/location.rs
+++ b/src/filter/location.rs
@@ -14,6 +14,27 @@ impl Loc {
 
 impl Display for Loc {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "line {}, column {}", self.line, self.column)
+        match self {
+            Loc { line: 0, column: 0 } => {
+                write!(f, "unknown location")
+            }
+            Loc { line, column } => {
+                write!(f, "line {}, column {}", line, column)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(0, 0, "unknown location")]
+    #[case(1, 2, "line 1, column 2")]
+    fn test_display(#[case] line: usize, #[case] column: usize, #[case] expected: &str) {
+        assert_eq!(format!("{}", Loc::new(line, column)), expected);
     }
 }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,6 +1,7 @@
 mod expr;
 mod interpreter;
 mod lexer;
+mod location;
 mod parser;
 mod token;
 mod value;

--- a/src/filter/parser.rs
+++ b/src/filter/parser.rs
@@ -38,7 +38,7 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
     fn or(&mut self) -> Result<Expr<'a>, Error> {
         let mut expr = self.and()?;
 
-        while matches!(self.tokens.peek(), Some(Ok(Token::Or))) {
+        while matches!(self.tokens.peek(), Some(Ok(Token::Or(..)))) {
             let token = self.tokens.next().unwrap()?;
             let right = self.and()?;
             expr = Expr::Logical(Box::new(expr), token, Box::new(right));
@@ -50,7 +50,7 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
     fn and(&mut self) -> Result<Expr<'a>, Error> {
         let mut expr = self.equality()?;
 
-        while matches!(self.tokens.peek(), Some(Ok(Token::And))) {
+        while matches!(self.tokens.peek(), Some(Ok(Token::And(..)))) {
             let token = self.tokens.next().unwrap()?;
             let right = self.equality()?;
             expr = Expr::Logical(Box::new(expr), token, Box::new(right));
@@ -64,7 +64,7 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
 
         if matches!(
             self.tokens.peek(),
-            Some(Ok(Token::Equals) | Ok(Token::NotEquals))
+            Some(Ok(Token::Equals(..)) | Ok(Token::NotEquals(..)))
         ) {
             let token = self.tokens.next().unwrap().unwrap();
             let right = self.comparison()?;
@@ -79,10 +79,10 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
 
         if matches!(
             self.tokens.peek(),
-            Some(Ok(Token::In))
-                | Some(Ok(Token::Contains))
-                | Some(Ok(Token::StartsWith))
-                | Some(Ok(Token::EndsWith))
+            Some(Ok(Token::In(..)))
+                | Some(Ok(Token::Contains(..)))
+                | Some(Ok(Token::StartsWith(..)))
+                | Some(Ok(Token::EndsWith(..)))
         ) {
             let token = self.tokens.next().unwrap().unwrap();
             let right = self.unary()?;
@@ -93,7 +93,7 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
     }
 
     fn unary(&mut self) -> Result<Expr<'a>, Error> {
-        if matches!(self.tokens.peek(), Some(Ok(Token::Not))) {
+        if matches!(self.tokens.peek(), Some(Ok(Token::Not(..)))) {
             let token = self.tokens.next().unwrap().unwrap();
             let right = self.unary()?;
             Ok(Expr::Unary(token, Box::new(right)))
@@ -104,10 +104,10 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
 
     fn primary(&mut self) -> Result<Expr<'a>, Error> {
         match self.tokens.peek() {
-            Some(Ok(Token::LeftParen)) => {
+            Some(Ok(Token::LeftParen(..))) => {
                 self.tokens.next();
                 let expr = self.or()?;
-                if let Some(Ok(Token::RightParen)) = self.tokens.next() {
+                if let Some(Ok(Token::RightParen(..))) = self.tokens.next() {
                     Ok(expr)
                 } else {
                     Err(errors::user(
@@ -116,19 +116,19 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
                     ))
                 }
             }
-            Some(Ok(Token::LeftBracket)) => {
+            Some(Ok(Token::LeftBracket(..))) => {
               self.tokens.next();
                 let mut items = Vec::new();
-                while !matches!(self.tokens.peek(), Some(Ok(Token::RightBracket))) {
+                while !matches!(self.tokens.peek(), Some(Ok(Token::RightBracket(..)))) {
                     items.push(self.literal()?);
-                    if matches!(self.tokens.peek(), Some(Ok(Token::Comma))) {
+                    if matches!(self.tokens.peek(), Some(Ok(Token::Comma(..)))) {
                         self.tokens.next();
                     } else {
                         break;
                     }
                 }
 
-                if let Some(Ok(Token::RightBracket)) = self.tokens.next() {
+                if let Some(Ok(Token::RightBracket(..))) = self.tokens.next() {
                   Ok(Expr::Literal(items.into()))
                 } else {
                   Err(errors::user(
@@ -138,7 +138,7 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
                 }
             }
             Some(Ok(Token::Property(..))) => {
-              if let Some(Ok(Token::Property(p))) = self.tokens.next() {
+              if let Some(Ok(Token::Property(.., p))) = self.tokens.next() {
                 Ok(Expr::Property(p))
               } else {
                 unreachable!()
@@ -155,15 +155,15 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
 
     fn literal(&mut self) -> Result<FilterValue, Error> {
         match self.tokens.next() {
-            Some(Ok(Token::True)) => Ok(true.into()),
-            Some(Ok(Token::False)) => Ok(false.into()),
-            Some(Ok(Token::Number(n))) => Ok(super::FilterValue::Number(n.parse().map_err(|e| errors::user_with_internal(
+            Some(Ok(Token::True(..))) => Ok(true.into()),
+            Some(Ok(Token::False(..))) => Ok(false.into()),
+            Some(Ok(Token::Number(.., n))) => Ok(super::FilterValue::Number(n.parse().map_err(|e| errors::user_with_internal(
               "Failed to parse the number '{n}' which you provided.",
               "Please make sure that the number is well formatted. It should be in the form 123, or 123.45.",
               e,
             ))?)),
-            Some(Ok(Token::String(s))) => Ok(s.replace("\\\"", "\"").replace("\\\\", "\\").into()),
-            Some(Ok(Token::Null)) => Ok(super::FilterValue::Null),
+            Some(Ok(Token::String(.., s))) => Ok(s.replace("\\\"", "\"").replace("\\\\", "\\").into()),
+            Some(Ok(Token::Null(..))) => Ok(super::FilterValue::Null),
             Some(Ok(token)) => Err(errors::user(
                 &format!("While parsing your filter, we found an unexpected '{}'.", token),
                 "Make sure that you have written a valid filter query.",
@@ -181,7 +181,7 @@ impl<'a, I: Iterator<Item = Result<Token<'a>, Error>>> Parser<'a, I> {
 mod tests {
     use rstest::rstest;
 
-    use crate::filter::FilterValue;
+    use crate::filter::{location::Loc, FilterValue};
 
     use super::*;
 
@@ -204,9 +204,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("!true", Expr::Unary(Token::Not, Box::new(Expr::Literal(true.into()))))]
-    #[case("!false", Expr::Unary(Token::Not, Box::new(Expr::Literal(false.into()))))]
-    #[case("!\"hello\"", Expr::Unary(Token::Not, Box::new(Expr::Literal("hello".into()))))]
+    #[case("!true", Expr::Unary(Token::Not(Loc::new(1, 1)), Box::new(Expr::Literal(true.into()))))]
+    #[case("!false", Expr::Unary(Token::Not(Loc::new(1, 1)), Box::new(Expr::Literal(false.into()))))]
+    #[case("!\"hello\"", Expr::Unary(Token::Not(Loc::new(1, 1)), Box::new(Expr::Literal("hello".into()))))]
     fn parsing_unary_expressions(#[case] input: &str, #[case] ast: Expr) {
         let tokens = crate::filter::lexer::Scanner::new(input);
         match Parser::parse(tokens.into_iter()) {
@@ -216,10 +216,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case("true == false", Expr::Binary(Box::new(Expr::Literal(true.into())), Token::Equals, Box::new(Expr::Literal(false.into()))))]
-    #[case("true != false", Expr::Binary(Box::new(Expr::Literal(true.into())), Token::NotEquals, Box::new(Expr::Literal(false.into()))))]
-    #[case("\"xyz\" startswith \"x\"", Expr::Binary(Box::new(Expr::Literal("xyz".into())), Token::StartsWith, Box::new(Expr::Literal("x".into()))))]
-    #[case("\"xyz\" endswith \"z\"", Expr::Binary(Box::new(Expr::Literal("xyz".into())), Token::EndsWith, Box::new(Expr::Literal("z".into()))))]
+    #[case("true == false", Expr::Binary(Box::new(Expr::Literal(true.into())), Token::Equals(Loc::new(1, 6)), Box::new(Expr::Literal(false.into()))))]
+    #[case("true != false", Expr::Binary(Box::new(Expr::Literal(true.into())), Token::NotEquals(Loc::new(1, 6)), Box::new(Expr::Literal(false.into()))))]
+    #[case("\"xyz\" startswith \"x\"", Expr::Binary(Box::new(Expr::Literal("xyz".into())), Token::StartsWith(Loc::new(1, 7)), Box::new(Expr::Literal("x".into()))))]
+    #[case("\"xyz\" endswith \"z\"", Expr::Binary(Box::new(Expr::Literal("xyz".into())), Token::EndsWith(Loc::new(1, 7)), Box::new(Expr::Literal("z".into()))))]
     fn parse_comparison_expressions(#[case] input: &str, #[case] ast: Expr) {
         let tokens = crate::filter::lexer::Scanner::new(input);
         match Parser::parse(tokens.into_iter()) {
@@ -229,9 +229,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("true && false", Expr::Logical(Box::new(Expr::Literal(true.into())), Token::And, Box::new(Expr::Literal(false.into()))))]
-    #[case("true || false", Expr::Logical(Box::new(Expr::Literal(true.into())), Token::Or, Box::new(Expr::Literal(false.into()))))]
-    #[case("true && (true || false)", Expr::Logical(Box::new(Expr::Literal(true.into())), Token::And, Box::new(Expr::Logical(Box::new(Expr::Literal(true.into())), Token::Or, Box::new(Expr::Literal(false.into()))))))]
+    #[case("true && false", Expr::Logical(Box::new(Expr::Literal(true.into())), Token::And(Loc::new(1, 6)), Box::new(Expr::Literal(false.into()))))]
+    #[case("true || false", Expr::Logical(Box::new(Expr::Literal(true.into())), Token::Or(Loc::new(1, 6)), Box::new(Expr::Literal(false.into()))))]
+    #[case("true && (true || false)", Expr::Logical(Box::new(Expr::Literal(true.into())), Token::And(Loc::new(1, 6)), Box::new(Expr::Logical(Box::new(Expr::Literal(true.into())), Token::Or(Loc::new(1, 15)), Box::new(Expr::Literal(false.into()))))))]
     fn parsing_logical_expressions(#[case] input: &str, #[case] ast: Expr) {
         let tokens = crate::filter::lexer::Scanner::new(input);
         match Parser::parse(tokens.into_iter()) {

--- a/src/filter/token.rs
+++ b/src/filter/token.rs
@@ -1,60 +1,91 @@
 use std::fmt::Display;
 
+use super::location::Loc;
+
 #[derive(Debug, PartialEq)]
 pub enum Token<'a> {
-    LeftParen,
-    RightParen,
-    LeftBracket,
-    RightBracket,
-    Comma,
+    LeftParen(Loc),
+    RightParen(Loc),
+    LeftBracket(Loc),
+    RightBracket(Loc),
+    Comma(Loc),
 
-    Property(&'a str),
+    Property(Loc, &'a str),
 
-    Null,
-    True,
-    False,
-    String(&'a str),
-    Number(&'a str),
+    Null(Loc),
+    True(Loc),
+    False(Loc),
+    String(Loc, &'a str),
+    Number(Loc, &'a str),
 
-    Equals,
-    NotEquals,
-    Contains,
-    In,
-    StartsWith,
-    EndsWith,
+    Equals(Loc),
+    NotEquals(Loc),
+    Contains(Loc),
+    In(Loc),
+    StartsWith(Loc),
+    EndsWith(Loc),
 
-    Not,
-    And,
-    Or,
+    Not(Loc),
+    And(Loc),
+    Or(Loc),
 }
 
 impl Token<'_> {
     pub fn lexeme(&self) -> &str {
         match self {
-            Token::LeftParen => "(",
-            Token::RightParen => ")",
-            Token::LeftBracket => "[",
-            Token::RightBracket => "]",
-            Token::Comma => ",",
+            Token::LeftParen(..) => "(",
+            Token::RightParen(..) => ")",
+            Token::LeftBracket(..) => "[",
+            Token::RightBracket(..) => "]",
+            Token::Comma(..) => ",",
 
-            Token::Property(s) => s,
+            Token::Property(.., s) => s,
 
-            Token::Null => "null",
-            Token::True => "true",
-            Token::False => "false",
-            Token::String(s) => s,
-            Token::Number(s) => s,
+            Token::Null(..) => "null",
+            Token::True(..) => "true",
+            Token::False(..) => "false",
+            Token::String(.., s) => s,
+            Token::Number(.., s) => s,
 
-            Token::Equals => "==",
-            Token::NotEquals => "!=",
-            Token::Contains => "contains",
-            Token::In => "in",
-            Token::StartsWith => "startswith",
-            Token::EndsWith => "endswith",
+            Token::Equals(..) => "==",
+            Token::NotEquals(..) => "!=",
+            Token::Contains(..) => "contains",
+            Token::In(..) => "in",
+            Token::StartsWith(..) => "startswith",
+            Token::EndsWith(..) => "endswith",
 
-            Token::Not => "!",
-            Token::And => "&&",
-            Token::Or => "||",
+            Token::Not(..) => "!",
+            Token::And(..) => "&&",
+            Token::Or(..) => "||",
+        }
+    }
+
+    pub fn location(&self) -> Loc {
+        match self {
+            Token::LeftParen(loc) => *loc,
+            Token::RightParen(loc) => *loc,
+            Token::LeftBracket(loc) => *loc,
+            Token::RightBracket(loc) => *loc,
+            Token::Comma(loc) => *loc,
+
+            Token::Property(loc, ..) => *loc,
+
+            Token::Null(loc) => *loc,
+            Token::True(loc) => *loc,
+            Token::False(loc) => *loc,
+            Token::String(loc, ..) => *loc,
+            Token::Number(loc, ..) => *loc,
+
+            Token::Equals(loc) => *loc,
+            Token::NotEquals(loc) => *loc,
+            Token::Contains(loc) => *loc,
+            Token::In(loc) => *loc,
+            Token::StartsWith(loc) => *loc,
+            Token::EndsWith(loc) => *loc,
+
+            Token::Not(loc) => *loc,
+            Token::And(loc) => *loc,
+            Token::Or(loc) => *loc,
         }
     }
 }
@@ -62,7 +93,7 @@ impl Token<'_> {
 impl Display for Token<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Token::String(s) => write!(f, "\"{s}\""),
+            Token::String(s, ..) => write!(f, "\"{s}\""),
             t => write!(f, "{}", t.lexeme()),
         }
     }


### PR DESCRIPTION
This PR introduces a location construct which can be used to keep track of where a specific token is found in the filter expression, allowing for improved error messages.