### PR TITLE
feat(github/star): Add support for backing up starred GitHub repos

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -10,3 +10,5 @@ backups:
   - kind: github/release
     from: orgs/SierraSoftworks
     filter: repo.public && !release.prerelease && !artifact.source-code
+  - kind: github/star
+    from: users/notheotherben

--- a/src/helpers/github.rs
+++ b/src/helpers/github.rs
@@ -569,8 +569,7 @@ impl MetadataSource for GitHubReleaseAsset {
 }
 
 #[allow(dead_code)]
-#[derive(PartialEq)]
-#[derive(Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum GitHubKind {
     Repo,
     Star,

--- a/src/helpers/github.rs
+++ b/src/helpers/github.rs
@@ -569,10 +569,13 @@ impl MetadataSource for GitHubReleaseAsset {
 }
 
 #[allow(dead_code)]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum GitHubKind {
+    #[serde(rename="github/repo")]
     Repo,
+    #[serde(rename="github/star")]
     Star,
+    #[serde(rename="github/release")]
     Release,
 }
 
@@ -590,30 +593,6 @@ impl GitHubKind {
             GitHubKind::Repo => "repos",
             GitHubKind::Star => "starred",
             GitHubKind::Release => "repos",
-        }
-    }
-}
-
-impl serde::Serialize for GitHubKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for GitHubKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s: &str = serde::Deserialize::deserialize(deserializer)?;
-        match s {
-            "github/repo" => Ok(GitHubKind::Repo),
-            "github/star" => Ok(GitHubKind::Star),
-            "github/release" => Ok(GitHubKind::Release),
-            _ => Err(serde::de::Error::custom(format!("Invalid kind: {}", s))),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ async fn run(args: Args) -> Result<(), Error> {
                         }
                     }
                     k if k == GitHubKind::Star.as_str() => {
-                        info!("Backing up repositories for {}", &policy);
+                        info!("Backing up starred repositories for {}", &policy);
 
                         let stream = github_star.run(policy, &CANCEL);
                         tokio::pin!(stream);

--- a/src/sources/github_repo.rs
+++ b/src/sources/github_repo.rs
@@ -10,6 +10,7 @@ use crate::{
     BackupSource,
 };
 
+#[derive(Clone)]
 pub struct GitHubRepoSource {
     client: GitHubClient,
     kind: GitHubKind,

--- a/src/sources/github_repo.rs
+++ b/src/sources/github_repo.rs
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case("users/cedi")]
+    #[case("users/notheotherben")]
     #[tokio::test]
     #[cfg_attr(feature = "pure_tests", ignore)]
     async fn get_stars(#[case] target: &str) {

--- a/src/sources/github_repo.rs
+++ b/src/sources/github_repo.rs
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case("users/cedi")]
+    #[case("users/notheotherben")]
     #[tokio::test]
     #[cfg_attr(feature = "pure_tests", ignore)]
     async fn get_repos(#[case] target: &str) {

--- a/src/sources/github_repo.rs
+++ b/src/sources/github_repo.rs
@@ -5,19 +5,19 @@ use tokio_stream::Stream;
 use crate::{
     entities::GitRepo,
     errors::{self},
-    helpers::{github::GitHubRepo, GitHubClient},
+    helpers::{github::GitHubRepo, GitHubClient, github::GitHubKind},
     policy::BackupPolicy,
     BackupSource,
 };
 
-#[derive(Clone, Default)]
 pub struct GitHubRepoSource {
     client: GitHubClient,
+    kind: GitHubKind,
 }
 
 impl BackupSource<GitRepo> for GitHubRepoSource {
     fn kind(&self) -> &str {
-        "github/repo"
+        self.kind.as_str()
     }
 
     fn validate(&self, policy: &BackupPolicy) -> Result<(), crate::Error> {
@@ -38,6 +38,11 @@ impl BackupSource<GitRepo> for GitHubRepoSource {
                 "Please specify either 'users/<username>' or 'orgs/<orgname>' as your target.",
             )),
 
+            t if t.starts_with("orgs/") && self.kind == GitHubKind::Star => Err(errors::user(
+                &format!("The target field '{target}' specifies an org which is not support for kind 'github/star'."),
+                "Please specify either 'users/<username>' as your target when using 'github/star' as kind.",
+            )),
+
             _ => Ok(()),
         }
     }
@@ -48,13 +53,14 @@ impl BackupSource<GitRepo> for GitHubRepoSource {
         cancel: &'a AtomicBool,
     ) -> impl Stream<Item = Result<GitRepo, errors::Error>> + 'a {
         let url = format!(
-            "{}/{}/repos",
+            "{}/{}/{}",
             policy
                 .properties
                 .get("api_url")
                 .unwrap_or(&"https://api.github.com".to_string())
                 .trim_end_matches('/'),
-            &policy.from.trim_matches('/')
+            &policy.from.trim_matches('/'),
+            self.kind.api_endpoint()
         );
 
         async_stream::try_stream! {
@@ -70,8 +76,25 @@ impl BackupSource<GitRepo> for GitHubRepoSource {
 
 impl GitHubRepoSource {
     #[allow(dead_code)]
-    pub fn with_client(client: GitHubClient) -> Self {
-        GitHubRepoSource { client }
+    pub fn with_client(client: GitHubClient, kind: GitHubKind) -> Self {
+        GitHubRepoSource {
+            client: client,
+            kind: kind,
+        }
+    }
+
+    pub fn repo() -> Self {
+        GitHubRepoSource {
+            client: GitHubClient::default(),
+            kind: GitHubKind::Repo,
+        }
+    }
+
+    pub fn star() -> Self {
+        GitHubRepoSource {
+            client: GitHubClient::default(),
+            kind: GitHubKind::Star,
+        }
     }
 }
 
@@ -81,15 +104,20 @@ mod tests {
 
     use rstest::rstest;
 
-    use crate::{BackupPolicy, BackupSource};
+    use crate::{helpers::github::GitHubKind, BackupPolicy, BackupSource};
 
     use super::GitHubRepoSource;
 
     static CANCEL: AtomicBool = AtomicBool::new(false);
 
     #[test]
-    fn check_name() {
-        assert_eq!(GitHubRepoSource::default().kind(), "github/repo");
+    fn check_name_repo() {
+        assert_eq!(GitHubRepoSource::repo().kind(), GitHubKind::Repo.as_str());
+    }
+
+    #[test]
+    fn check_name_star() {
+        assert_eq!(GitHubRepoSource::star().kind(), GitHubKind::Star.as_str());
     }
 
     #[rstest]
@@ -98,8 +126,8 @@ mod tests {
     #[case("notheotherben", false)]
     #[case("sierrasoftworks/github-backup", false)]
     #[case("users/notheotherben/repos", false)]
-    fn validation(#[case] from: &str, #[case] success: bool) {
-        let source = GitHubRepoSource::default();
+    fn validation_repo(#[case] from: &str, #[case] success: bool) {
+        let source = GitHubRepoSource::repo();
 
         let policy = serde_yaml::from_str(&format!(
             r#"
@@ -119,17 +147,73 @@ mod tests {
     }
 
     #[rstest]
-    #[case("users/notheotherben")]
+    #[case("users/notheotherben", true)]
+    #[case("orgs/sierrasoftworks", false)]
+    fn validation_stars(#[case] from: &str, #[case] success: bool) {
+        let source = GitHubRepoSource::star();
+
+        let policy = serde_yaml::from_str(&format!(
+            r#"
+            kind: github/star
+            from: {}
+            to: /tmp
+            "#,
+            from
+        ))
+        .expect("parse policy");
+
+        if success {
+            source.validate(&policy).expect("validation to succeed");
+        } else {
+            source.validate(&policy).expect_err("validation to fail");
+        }
+    }
+
+    #[rstest]
+    #[case("users/cedi")]
     #[tokio::test]
     #[cfg_attr(feature = "pure_tests", ignore)]
     async fn get_repos(#[case] target: &str) {
         use tokio_stream::StreamExt;
 
-        let source = GitHubRepoSource::default();
+        let source = GitHubRepoSource::repo();
 
         let policy: BackupPolicy = serde_yaml::from_str(&format!(
             r#"
           kind: github/repo
+          from: {}
+          to: /tmp
+          credentials: {}
+        "#,
+            target,
+            std::env::var("GITHUB_TOKEN")
+                .map(|t| format!("!Token {t}"))
+                .unwrap_or_else(|_| "!None".to_string())
+        ))
+        .unwrap();
+
+        println!("Using credentials: {}", policy.credentials);
+
+        let stream = source.load(&policy, &CANCEL);
+        tokio::pin!(stream);
+
+        while let Some(repo) = stream.next().await {
+            println!("{}", repo.expect("Failed to load repo"));
+        }
+    }
+
+    #[rstest]
+    #[case("users/cedi")]
+    #[tokio::test]
+    #[cfg_attr(feature = "pure_tests", ignore)]
+    async fn get_stars(#[case] target: &str) {
+        use tokio_stream::StreamExt;
+
+        let source = GitHubRepoSource::star();
+
+        let policy: BackupPolicy = serde_yaml::from_str(&format!(
+            r#"
+          kind: github/star
           from: {}
           to: /tmp
           credentials: {}


### PR DESCRIPTION
This commit adds support for backing up starred repositories, using a backup rule with `kind: github/star`.

To achieve this, the src/sources/github_repo.rs file was modified to support both the https://api.github.com/users/{USER}/repos and the https://api.github.com/users/{USER}/repos API-endpoint. This is made possible by introducing separate constructors for `repo` and `star` which set a new `kind` enum-member. `kind` is used to return the kind string in `fn kind()` as well as to construct the correct API-endpoint in `fn load`.

Documentation and examples for `kind: github/star` were added, as well as appropriate unit-testing.

To cut down on "magic string" usage, the enum used for `kind` is specified in src/helpers/github.rs and also includes the release kind, making it possible to use the enum throughout the code, instead of having to rely on the raw strings.

Additionally, this commit adds on to the documentation in README.md by providing better documentation of the available tokens in the `filter` expressions.