### PR TITLE
fix(docker build): binary not marked as executable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,6 +207,10 @@ jobs:
         with:
           name: github-backup-${{ env.PLATFORM_PAIR }}
 
+      - name: mark artifact as executable
+        run: |
+          chmod +x github-backup
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Currently, the github-backup binary is not marked as executable in the docker container, resulting in the following error:

```
docker: Error response from daemon: failed to create task for container:
failed to create shim task: OCI runtime create failed: runc create
failed: unable to start container process: error during container init:
exec: "/usr/local/bin/github-backup": permission denied: unknown.
```

after a bit of debugging, I found the issue to be that uploading the binary to the github artifacts and downloading it again removes the executable flag.