### PR TITLE
feat: Add support for backing up repositories owned by the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,17 @@ schedule: "0 * * * *"
 
 backups:
   - kind: github/repo
-    from: users/my-user
+    from: user # The user associated with the provided credentials
     to: /backups/personal
     credentials: !UsernamePassword:
       username: "<your username>"
       password: "<your personal access token>"
+    properties:
+      query: "affiliation=owner" # Additional query parameters to pass to GitHub when fetching repositories
+  - kind: github/repo
+    from: "users/another-user"
+    to: /backups/friend
+    credentials: !Token "your_github_token"
   - kind: github/repo
     from: "orgs/my-org"
     to: /backups/work

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,14 +1,31 @@
 schedule: "0 * * * *"
 
 backups:
+  # Backup all the repositories that the provided credentials have access to
+  - kind: github/repo
+    from: user
+    to: /backup/github
+    credentials: !Token your_access_token
+
+  # Backup the repository from "notheotherben" called "nix-env"
   - kind: github/repo
     from: users/notheotherben
+    to: /backup/github
     filter: repo.name == "nix-env"
+
+  # Backup public, non-forked, repositories called "git-tool" or "grey" from the "SierraSoftworks" organization
   - kind: github/repo
     from: orgs/SierraSoftworks
+    to: /backup/github
     filter: repo.public && !repo.fork && repo.name in ["git-tool", "grey"]
+
+  # Backup production non-source releases from the "SierraSoftworks" organization
   - kind: github/release
     from: orgs/SierraSoftworks
+    to: /backup/github
     filter: repo.public && !release.prerelease && !artifact.source-code
+
+  # Backup all repositories that the user `notheotherben` has starred
   - kind: github/star
     from: users/notheotherben
+    to: /backup/github

--- a/src/helpers/github.rs
+++ b/src/helpers/github.rs
@@ -573,7 +573,7 @@ impl MetadataSource for GitHubReleaseAsset {
 
 #[allow(dead_code)]
 #[derive(PartialEq, Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum GitHubKind {
+pub enum GitHubArtifactKind {
     #[serde(rename = "github/repo")]
     Repo,
     #[serde(rename = "github/star")]
@@ -582,20 +582,20 @@ pub enum GitHubKind {
     Release,
 }
 
-impl GitHubKind {
+impl GitHubArtifactKind {
     pub fn as_str(&self) -> &'static str {
         match self {
-            GitHubKind::Repo => "github/repo",
-            GitHubKind::Star => "github/star",
-            GitHubKind::Release => "github/release",
+            GitHubArtifactKind::Repo => "github/repo",
+            GitHubArtifactKind::Star => "github/star",
+            GitHubArtifactKind::Release => "github/release",
         }
     }
 
     pub fn api_endpoint(&self) -> &'static str {
         match self {
-            GitHubKind::Repo => "repos",
-            GitHubKind::Star => "starred",
-            GitHubKind::Release => "repos",
+            GitHubArtifactKind::Repo => "repos",
+            GitHubArtifactKind::Star => "starred",
+            GitHubArtifactKind::Release => "repos",
         }
     }
 }
@@ -720,15 +720,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case("github/repo", GitHubKind::Repo, "repos")]
-    #[case("github/star", GitHubKind::Star, "starred")]
-    #[case("github/release", GitHubKind::Release, "repos")]
+    #[case("github/repo", GitHubArtifactKind::Repo, "repos")]
+    #[case("github/star", GitHubArtifactKind::Star, "starred")]
+    #[case("github/release", GitHubArtifactKind::Release, "repos")]
     fn test_deserialize_gh_repo_kind(
         #[case] kind_str: &str,
-        #[case] expected_kind: GitHubKind,
+        #[case] expected_kind: GitHubArtifactKind,
         #[case] url: &str,
     ) {
-        let kind: GitHubKind = serde_yaml::from_str(&format!("\"{}\"", kind_str)).unwrap();
+        let kind: GitHubArtifactKind = serde_yaml::from_str(&format!("\"{}\"", kind_str)).unwrap();
 
         assert_eq!(kind, expected_kind);
         assert_eq!(kind.as_str(), kind_str);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ mod policy;
 mod sources;
 mod telemetry;
 
-use crate::helpers::github::GitHubKind;
+use crate::helpers::github::GitHubArtifactKind;
 pub use entities::BackupEntity;
 pub use filter::{Filter, FilterValue, Filterable};
 pub use policy::BackupPolicy;
@@ -76,19 +76,19 @@ async fn run(args: Args) -> Result<(), Error> {
                 let _policy_span = tracing::info_span!("backup.policy", policy = %policy).entered();
 
                 match policy.kind.as_str() {
-                    k if k == GitHubKind::Repo.as_str() => {
+                    k if k == GitHubArtifactKind::Repo.as_str() => {
                         info!("Backing up repositories for {}", &policy);
                         github_repo
                             .run(policy, &LoggingPairingHandler, &CANCEL)
                             .await;
                     }
-                    k if k == GitHubKind::Star.as_str() => {
+                    k if k == GitHubArtifactKind::Star.as_str() => {
                         info!("Backing up starred repositories for {}", &policy);
                         github_star
                             .run(policy, &LoggingPairingHandler, &CANCEL)
                             .await;
                     }
-                    k if k == GitHubKind::Release.as_str() => {
+                    k if k == GitHubArtifactKind::Release.as_str() => {
                         info!("Backing up release artifacts for {}", &policy);
                         github_release
                             .run(policy, &LoggingPairingHandler, &CANCEL)

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -5,8 +5,6 @@ pub use traced_stream::*;
 use tracing_batteries::*;
 
 pub fn setup() -> Session {
-    Session::new("github-backup", version!()).with_battery(
-        OpenTelemetry::new("https://api.honeycomb.io")
-            .with_protocol(OpenTelemetryProtocol::HttpJson),
-    )
+    Session::new("github-backup", version!())
+        .with_battery(OpenTelemetry::new("").with_protocol(OpenTelemetryProtocol::HttpJson))
 }


### PR DESCRIPTION
This PR adds support for backing up repos owned by the current user, without needing to specify the current user's username. This solves the issue of being unable to backup private personal repos (given the way the GitHub API works when requesting `/users/${username}/repos` regardless of whether your username matches `${username}`.

In addition to this, I've included support for a new `properties.query` field which can be used to pass query parameters to the GitHub API, allowing you to select which repos get included in a query (for example, you can filter repos for the current user to only include `owner`, or include any combination of the default `owner,collaborator,organization_member`.

Oh, and I should mention that we now handle cases where you don't specify an `OTEL_EXPORTER_OTLP_ENDPOINT` without reporting an error - and correctly fall back to logging to the terminal.