### PR TITLE
feat: Add support for backing up single repositories using from: repos/<owner>/<name>

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,33 @@ backups:
       password: "<your personal access token>"
     properties:
       query: "affiliation=owner" # Additional query parameters to pass to GitHub when fetching repositories
+
   - kind: github/repo
     from: "users/another-user"
     to: /backups/friend
     credentials: !Token "your_github_token"
+
   - kind: github/repo
     from: "orgs/my-org"
     to: /backups/work
     filter: '!repo.fork && repo.name contains "awesome"'
+
   - kind: github/release
     from: "orgs/my-org"
     to: /backups/releases
     filter: '!release.prerelease && !asset.source-code'
+
+  # You can also backup single repositories directly if you wish
+  - kind: github/repo
+    from: "repos/my-org/repo"
+    to: /backups/work
+
+  # This is particularly useful for backing up release artifacts for
+  # specific projects.
+  - kind: github/release
+    from: "repos/my-org/repo"
+    to: /backups/releases
+    filter: '!release.prerelease'
 ```
 
 ### OpenTelemetry Reporting

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -29,3 +29,12 @@ backups:
   - kind: github/star
     from: users/notheotherben
     to: /backup/github
+
+  - kind: github/repo
+    from: repos/SierraSoftworks/github-backup
+    to: /backup/github
+
+  - kind: github/release
+    from: repos/SierraSoftworks/github-backup
+    to: /backup/github-releases
+    filter: '!release.prerelease'


### PR DESCRIPTION
This PR introduces support for targeting single repositories for backup operations, which is particularly useful for backing up releases for a single key repo (where you may wish to not do so for all of your repositories). This also works well in cases where you want to use this app for backing up a single repo and don't want to run a list operation over all of your other repos in the process (which can allow it to run without requiring a GitHub access token in some cases).