### PR TITLE
feat: Add support for fetching specific refspecs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn deserialize_example_config() {
-        let args = Args::parse_from(&[
+        let args = Args::parse_from([
             "github-backup",
             "--config",
             &format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "pure_tests", ignore)]
     fn deserialize_example_config() {
         let args = Args::parse_from([
             "github-backup",

--- a/src/engines/git.rs
+++ b/src/engines/git.rs
@@ -134,6 +134,8 @@ impl GitEngine {
 
         let original_head = repository.head_id().ok();
 
+        let default_refspecs = vec!["+refs/heads/*:refs/remotes/origin/*".to_string()];
+
         trace!(
             "Configuring fetch operation for repository {}",
             target.display()
@@ -150,7 +152,12 @@ impl GitEngine {
             )
         })?
             .with_fetch_tags(Tags::All)
-            .with_refspecs(["+refs/heads/*:refs/remotes/origin/*"], gix::remote::Direction::Fetch)
+            .with_refspecs(
+              repo.refspecs.as_ref().unwrap_or(&default_refspecs)
+                .iter()
+                .map(|s| gix::bstr::BString::from(s.as_str()))
+                .collect::<Vec<gix::bstr::BString>>(),
+              gix::remote::Direction::Fetch)
             .map_err(|e| {
                 errors::user_with_internal(
                     &format!(
@@ -319,6 +326,7 @@ mod tests {
         let repo = GitRepo::new(
             "SierraSoftworks/grey",
             "https://github.com/sierrasoftworks/grey.git",
+            None,
         );
 
         let state1 = agent

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -41,6 +41,6 @@ entity!(HttpFile(url: U => String) {
     with_content_type => content_type: Option<String>,
 });
 
-entity!(GitRepo(clone_url: U => String) {
+entity!(GitRepo(clone_url: U => String, refspecs: R => Option<Vec<String>>) {
     with_credentials => credentials: Credentials,
 });

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -178,7 +178,7 @@ mod tests {
             async_stream::stream! {
               let repos: Vec<crate::helpers::github::GitHubRepo> = load_test_file("github.repos.0.json").unwrap();
               for repo in repos {
-                yield Ok(GitRepo::new(repo.full_name.as_str(), repo.clone_url.as_str())
+                yield Ok(GitRepo::new(repo.full_name.as_str(), repo.clone_url.as_str(), None)
                     .with_metadata_source(&repo));
               }
             }

--- a/src/sources/github_repo.rs
+++ b/src/sources/github_repo.rs
@@ -86,13 +86,19 @@ impl BackupSource<GitRepo> for GitHubRepoSource {
         async_stream::try_stream! {
           if matches!(target, GitHubRepoSourceKind::Repo(_)) {
             let repo = self.client.get::<GitHubRepo>(url, &policy.credentials, cancel).await?;
-            yield GitRepo::new(repo.full_name.as_str(), repo.clone_url.as_str())
+            yield GitRepo::new(
+              repo.full_name.as_str(),
+              repo.clone_url.as_str(),
+              policy.properties.get("refspecs").map(|r| r.split(",").map(|r| r.to_string()).collect::<Vec<String>>()))
                 .with_credentials(policy.credentials.clone())
                 .with_metadata_source(&repo);
           } else {
             for await repo in self.client.get_paginated::<GitHubRepo>(url, &policy.credentials, cancel) {
               let repo = repo?;
-              yield GitRepo::new(repo.full_name.as_str(), repo.clone_url.as_str())
+              yield GitRepo::new(
+                repo.full_name.as_str(),
+                repo.clone_url.as_str(),
+                policy.properties.get("refspecs").map(|r| r.split(",").map(|r| r.to_string()).collect::<Vec<String>>()))
                   .with_credentials(policy.credentials.clone())
                   .with_metadata_source(&repo);
             }


### PR DESCRIPTION
This PR adds support for setting a `properties.refspecs` option for each backup policy fetching a GitHub repo, allowing you to customize which refs are backed up.

In my case, this also allows me to work around an issue with the way Synology creates `@eaDir` directories which results in issues crafting a ref map during the fetch operation.