### PR TITLE
tweak: Improve error reporting for Git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,9 +1770,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human-errors"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44acdf3f328626384ebd297ee1321b32319745eb12c339b16a738028f952cfdf"
+checksum = "f83bca1f8f2cc0ec71b29df67fda94f78b32e800f22f2da118a9eaa3a5bfe612"
 
 [[package]]
 name = "human_format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.31"
 gix = { version = "0.68.0", features = [
   "blocking-http-transport-reqwest-rust-tls",
 ] }
-human-errors = "0.1.3"
+human-errors = "0.1.5"
 log = "0.4.22"
 parse_link_header = "0.4.0"
 pin-project = "1.1.7"


### PR DESCRIPTION
This should help improve the error reports by providing recursive causal information in cases where this is available.