### PR TITLE
fix: Configure a fallback git committer for clones and fetches

### DIFF
--- a/src/engines/git.rs
+++ b/src/engines/git.rs
@@ -270,12 +270,12 @@ impl GitEngine {
             self.update_config(repo, |cfg| {
                 cfg.set_raw_value(
                     &gix::config::tree::gitoxide::Committer::NAME_FALLBACK,
-                    "no name configured during clone",
+                    "github-backup",
                 )
                 .expect("works - statically known");
                 cfg.set_raw_value(
                     &gix::config::tree::gitoxide::Committer::EMAIL_FALLBACK,
-                    "noEmailAvailable@example.com",
+                    "github-backup@sierrasoftworks.github.io",
                 )
                 .expect("works - statically known");
 


### PR DESCRIPTION
This should resolve the following error when attempting to clone a repository on a system which lacks a globally configured Git `user.name` and `user.email`.

> Oh no! Unable to fetch from remote git repository 'https://github.com/your/repo.git'
> 
> This was caused by:
>  - Failed to update references to their new position to match their remote locations
>  - The reflog could not be created or updated
>  - reflog messages need a committer which isn't set
>
> To try and fix this, you can:
>  - Make sure that the repository is available and correctly configured.