### PR TITLE
feat: support multiple backup targets per policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ The `owner` field selects the Forgejo user or organization which should own the
 mirrored repositories (and host the releases). The `credentials` field accepts
 the same `!Token` and `!UsernamePassword` forms as GitHub credentials.
 
+#### Backing up to multiple destinations
+
+The `to` field also accepts a **list** of targets, allowing a single policy to
+mirror its source to several destinations at once. The source (for example the
+GitHub API) is queried only once, and each resulting repository or release is
+written to every configured target. You can freely mix filesystem paths and
+remote targets within the same list.
+
+```yaml
+backups:
+  # Back up a repository to the local filesystem *and* a Forgejo instance
+  - kind: github/repo
+    from: repos/SierraSoftworks/github-backup
+    to:
+      - /backups/github
+      - kind: forgejo/repo
+        address: https://forgejo.example.com
+        owner: backups
+        credentials: !Token "your_forgejo_access_token"
+```
+
+When `to` is omitted it defaults to a single `./backups` filesystem target, and
+a single target (a path string or a remote map) continues to work exactly as
+before.
+
 ### OpenTelemetry Reporting
 
 In addition to the standard logging output, this tool also supports reporting metrics to an

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -56,3 +56,14 @@ backups:
       owner: backups
       credentials: !Token forgejo_access_token
     filter: '!release.prerelease'
+
+
+  # Backup repos to the local filesystem and Forgejo simultaneously
+  - kind: github/repo
+    from: repos/SierraSoftworks/github-backup
+    to:
+      - /backup/github
+      - kind: forgejo/repo
+        address: https://forgejo.example.com
+        owner: backups
+        credentials: !Token forgejo_access_token

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -19,7 +19,7 @@ pub struct Pairing<E: BackupEntity, S: BackupSource<E>, T: BackupEngine<E>> {
 }
 
 impl<
-    E: BackupEntity + Send + Sync + 'static,
+    E: BackupEntity + Clone + Send + Sync + 'static,
     S: BackupSource<E> + Send + Sync + 'static,
     T: BackupEngine<E> + Send + Sync + Clone + 'static,
 > Pairing<E, S, T>
@@ -94,18 +94,15 @@ impl<
           let mut join_set: JoinSet<Result<(E, BackupState), crate::Error>> = JoinSet::new();
 
           for await entity in self.source.load(policy, cancel).trace(tracing::info_span!("backup.source.load")) {
-              while join_set.len() >= self.concurrency_limit {
-                debug!("Reached concurrency limit of {}, waiting for a task to complete", self.concurrency_limit);
-                yield join_set.join_next().await.unwrap().unwrap();
-              }
-
               if cancel.load(std::sync::atomic::Ordering::Relaxed) {
                   break;
               }
 
               let entity = entity?;
               if self.dry_run {
-                  info!("Would backup {entity} to {}", &policy.to);
+                  for to in policy.to.iter() {
+                      info!("Would backup {entity} to {to}");
+                  }
                   yield Ok((entity, BackupState::Skipped));
                   continue;
               }
@@ -122,13 +119,23 @@ impl<
                 }
               }
 
-              {
-                let span = tracing_batteries::prelude::info_span!(parent: &span, "backup.step", item=%entity);
+              // A single source entity may be mirrored to several targets. We
+              // load the entity once (above) and fan out one backup task per
+              // configured target so we don't re-query the source for each
+              // destination.
+              for to in policy.to.iter() {
+                while join_set.len() >= self.concurrency_limit {
+                  debug!("Reached concurrency limit of {}, waiting for a task to complete", self.concurrency_limit);
+                  yield join_set.join_next().await.unwrap().unwrap();
+                }
+
+                let span = tracing_batteries::prelude::info_span!(parent: &span, "backup.step", item=%entity, target=%to);
                 let target = self.target.clone();
-                let to = policy.to.clone();
+                let to = to.clone();
+                let entity = entity.clone();
                 join_set.spawn(async move {
                     debug!("Starting backup of {entity}");
-                    target.backup(&entity, &to, cancel).await.map(|state| (entity, state.clone()))
+                    target.backup(&entity, &to, cancel).await.map(|state| (entity, state))
                 }.instrument(span));
               }
           }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -4,14 +4,14 @@ use std::fmt::{Debug, Display, Formatter};
 
 use crate::Filter;
 use crate::entities::Credentials;
-use crate::target::BackupTarget;
+use crate::target::BackupTargets;
 
 #[derive(Deserialize)]
 pub struct BackupPolicy {
     pub kind: String,
     pub from: String,
     #[serde(default)]
-    pub to: BackupTarget,
+    pub to: BackupTargets,
     #[serde(default)]
     pub credentials: Credentials,
     #[serde(default)]
@@ -52,7 +52,9 @@ mod tests {
         assert_eq!(policy.from, "source");
         assert_eq!(
             policy.to,
-            BackupTarget::FileSystem(std::path::PathBuf::from("/tmp/backup"))
+            BackupTargets(vec![crate::target::BackupTarget::FileSystem(
+                std::path::PathBuf::from("/tmp/backup")
+            )])
         );
         assert_eq!(
             policy.credentials,

--- a/src/target.rs
+++ b/src/target.rs
@@ -83,6 +83,99 @@ impl<'de> Deserialize<'de> for BackupTarget {
     }
 }
 
+/// One or more [`BackupTarget`]s that a single backup policy should write to.
+///
+/// Accepting a list of targets allows a policy's source data (for example the
+/// GitHub API) to be queried once while the resulting entities are mirrored to
+/// several destinations.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BackupTargets(pub Vec<BackupTarget>);
+
+impl BackupTargets {
+    pub fn iter(&self) -> std::slice::Iter<'_, BackupTarget> {
+        self.0.iter()
+    }
+}
+
+impl Default for BackupTargets {
+    fn default() -> Self {
+        BackupTargets(vec![BackupTarget::default()])
+    }
+}
+
+impl Display for BackupTargets {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (i, target) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{target}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for BackupTargets {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // The `to` field accepts a single target (a filesystem path string or a
+        // remote target map) or a sequence mixing both forms. We dispatch via a
+        // visitor so the underlying deserializer streams each target directly,
+        // preserving support for YAML-tagged credentials.
+        struct TargetsVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for TargetsVisitor {
+            type Value = BackupTargets;
+
+            fn expecting(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a backup target or a list of backup targets")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BackupTargets(vec![BackupTarget::FileSystem(
+                    PathBuf::from(value),
+                )]))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BackupTargets(vec![BackupTarget::FileSystem(
+                    PathBuf::from(value),
+                )]))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let target =
+                    RemoteTarget::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(BackupTargets(vec![BackupTarget::Remote(target)]))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut targets = Vec::new();
+                while let Some(target) = seq.next_element::<BackupTarget>()? {
+                    targets.push(target);
+                }
+                Ok(BackupTargets(targets))
+            }
+        }
+
+        deserializer.deserialize_any(TargetsVisitor)
+    }
+}
+
 /// A backup target which uploads repositories and/or release artifacts to a
 /// remote service (such as a Forgejo instance) using its REST API.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -196,6 +289,65 @@ mod tests {
         assert_eq!(
             BackupTarget::default(),
             BackupTarget::FileSystem(PathBuf::from("./backups"))
+        );
+    }
+
+    #[test]
+    fn deserialize_targets_single_string() {
+        let targets: BackupTargets = serde_yaml::from_str("/tmp/backup").unwrap();
+        assert_eq!(
+            targets,
+            BackupTargets(vec![BackupTarget::FileSystem(PathBuf::from("/tmp/backup"))])
+        );
+    }
+
+    #[test]
+    fn deserialize_targets_single_remote() {
+        let targets: BackupTargets = serde_yaml::from_str(
+            r#"
+            kind: forgejo/repo
+            address: https://forgejo.example.com
+            owner: backups
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(targets.0.len(), 1);
+        assert!(matches!(targets.0[0], BackupTarget::Remote(_)));
+    }
+
+    #[test]
+    fn deserialize_targets_mixed_list() {
+        let targets: BackupTargets = serde_yaml::from_str(
+            r#"
+            - /tmp/backup
+            - kind: forgejo/repo
+              address: https://forgejo.example.com
+              owner: backups
+              credentials: !Token abc123
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            targets,
+            BackupTargets(vec![
+                BackupTarget::FileSystem(PathBuf::from("/tmp/backup")),
+                BackupTarget::Remote(RemoteTarget {
+                    kind: RemoteTargetKind::ForgejoRepo,
+                    address: "https://forgejo.example.com".to_string(),
+                    owner: "backups".to_string(),
+                    credentials: Credentials::Token("abc123".to_string()),
+                }),
+            ])
+        );
+    }
+
+    #[test]
+    fn default_targets_is_single_filesystem() {
+        assert_eq!(
+            BackupTargets::default(),
+            BackupTargets(vec![BackupTarget::FileSystem(PathBuf::from("./backups"))])
         );
     }
 }


### PR DESCRIPTION
Allow the policy 'to' field to accept a list of targets so a source is queried once and mirrored to several destinations. Adds a BackupTargets type with custom deserialization (single string, single map, or a mixed sequence), fans out one backup task per target in the pairing loop, and documents the capability in the README and example config.