### PR TITLE
ci: replace deprecated actions-rs/audit-check with rustsec/audit-check

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rs/audit-check@v1.2.0
+      - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Following up on the migration away from the deprecated, unmaintained `actions-rs` actions.

This repo already uses `dtolnay/rust-toolchain` for toolchain setup, so there was no `actions-rs/toolchain` to replace. The remaining `actions-rs` usage was `actions-rs/audit-check` in the Security Audit workflow, which is migrated here to its maintained successor [`rustsec/audit-check`](https://github.com/rustsec/audit-check) (a drop-in fork under the RustSec org, same `token` input).

## Changes

- **`.github/workflows/security-audit.yml`** — `actions-rs/audit-check@v1.2.0` → `rustsec/audit-check@v2.0.0`

https://claude.ai/code/session_01Gg83Wh91H6bkexCmhpwVBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg83Wh91H6bkexCmhpwVBa)_