### PR TITLE
Add HTTP-based cron monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,33 @@ OTEL_TRACES_SAMPLER=traceidratio
 OTEL_TRACES_SAMPLER_ARG=1.0
 ```
 
+### Cron Monitoring
+
+If you run this tool on a schedule, you'll often want to be alerted when a backup
+run fails to start or complete. To support this, GitHub Backup can report the
+state of each scheduled run to an HTTP-based cron monitoring service such as
+[Sentry Cron Monitors](https://docs.sentry.io/product/crons/) or
+[healthchecks.io](https://healthchecks.io/).
+
+Monitoring is configured under the top-level `monitor` key, where you can provide
+a separate URL for each state you care about. Each URL is fetched with a simple
+HTTP `GET` request when the corresponding state is reached, and any state you
+omit is simply not reported.
+
+```yaml
+monitor:
+  # Fetched when a backup run starts.
+  start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
+  # Fetched when a backup run completes successfully.
+  success: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=ok
+  # Fetched when a backup run completes with one or more errors.
+  failure: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=error
+```
+
+A run is reported as a `failure` if any policy reports one or more errors, and as
+a `success` otherwise. Reporting is best-effort: if the monitoring service can't
+be reached, a warning is logged but the backup run itself is unaffected.
+
 ## Filters
 
 This tool allows you to configure filters to control which GitHub repositories are backed up and

--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ state of each scheduled run to an HTTP-based cron monitoring service such as
 [Sentry Cron Monitors](https://docs.sentry.io/product/crons/) or
 [healthchecks.io](https://healthchecks.io/).
 
-Monitoring is configured under the top-level `monitor` key, where you can provide
+Monitoring is configured under the top-level `ping` key, where you can provide
 a separate URL for each state you care about. Each URL is fetched with a simple
 HTTP `GET` request when the corresponding state is reached, and any state you
 omit is simply not reported.
 
 ```yaml
-monitor:
+ping:
   # Fetched when a backup run starts.
   start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
   # Fetched when a backup run completes successfully.

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -79,7 +79,8 @@ export default defineUserConfig({
           children: [
             '/guide/README.md',
             '/guide/enterprise.md',
-            '/guide/telemetry.md'
+            '/guide/telemetry.md',
+            '/guide/monitors.md'
           ]
         },
         {

--- a/docs/guide/monitors.md
+++ b/docs/guide/monitors.md
@@ -11,14 +11,14 @@ monitoring service to track whether your backups are running as expected and to
 alert you if they stop.
 
 ## Configuration
-Monitoring is configured under the top-level `monitor` key in your configuration
+Monitoring is configured under the top-level `ping` key in your configuration
 file. You may provide a separate URL for each of the `start`, `success`, and
 `failure` states, and any state you leave out is simply not reported.
 
 ```yaml
 schedule: "0 * * * *"
 
-monitor:
+ping:
   # Fetched when a backup run starts.
   start: https://example.com/monitor/start
   # Fetched when a backup run completes successfully.
@@ -51,7 +51,7 @@ state at the same URL while varying the `status` value to report the lifecycle o
 your backups.
 
 ```yaml
-monitor:
+ping:
   start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
   success: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=ok
   failure: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=error
@@ -62,7 +62,7 @@ monitor:
 `/start` and `/fail` suffixes used to signal the start and failure of a run.
 
 ```yaml
-monitor:
+ping:
   start: https://hc-ping.com/your-uuid/start
   success: https://hc-ping.com/your-uuid
   failure: https://hc-ping.com/your-uuid/fail

--- a/docs/guide/monitors.md
+++ b/docs/guide/monitors.md
@@ -1,0 +1,69 @@
+# Cron Monitoring
+GitHub Backup is designed to run unattended on a schedule, which makes it
+important to know when a backup run fails to start or complete. To support this,
+GitHub Backup can report the state of each scheduled run to an HTTP-based cron
+monitoring service such as [Sentry Cron Monitors](https://docs.sentry.io/product/crons/)
+or [healthchecks.io](https://healthchecks.io/).
+
+Whenever a backup run starts or completes, GitHub Backup will make a simple HTTP
+`GET` request to the URL you've configured for that state, allowing your
+monitoring service to track whether your backups are running as expected and to
+alert you if they stop.
+
+## Configuration
+Monitoring is configured under the top-level `monitor` key in your configuration
+file. You may provide a separate URL for each of the `start`, `success`, and
+`failure` states, and any state you leave out is simply not reported.
+
+```yaml
+schedule: "0 * * * *"
+
+monitor:
+  # Fetched when a backup run starts.
+  start: https://example.com/monitor/start
+  # Fetched when a backup run completes successfully.
+  success: https://example.com/monitor/success
+  # Fetched when a backup run completes with one or more errors.
+  failure: https://example.com/monitor/failure
+
+backups:
+  - kind: github/repo
+    from: user
+    to: /backup/github
+    credentials: !Token your_access_token
+```
+
+A run is reported as a `failure` if any backup policy reports one or more errors,
+and as a `success` otherwise.
+
+::: tip
+Reporting is best-effort. If the monitoring service can't be reached, a warning is
+logged but the backup run itself is never affected, ensuring that a flaky monitor
+can't cause an otherwise healthy backup to be reported as failed.
+:::
+
+## Examples
+
+### Sentry
+[Sentry's Cron Monitors](https://docs.sentry.io/product/crons/getting-started/http/)
+expose a check-in URL which accepts a `status` query parameter. You can point each
+state at the same URL while varying the `status` value to report the lifecycle of
+your backups.
+
+```yaml
+monitor:
+  start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
+  success: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=ok
+  failure: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=error
+```
+
+### healthchecks.io
+[healthchecks.io](https://healthchecks.io/) provides a base ping URL, with
+`/start` and `/fail` suffixes used to signal the start and failure of a run.
+
+```yaml
+monitor:
+  start: https://hc-ping.com/your-uuid/start
+  success: https://hc-ping.com/your-uuid
+  failure: https://hc-ping.com/your-uuid/fail
+```

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,5 +1,14 @@
 schedule: "0 * * * *"
 
+# Optionally report the status of each backup run to an HTTP-based cron
+# monitoring service (such as Sentry Crons or healthchecks.io). Each URL is
+# fetched with a simple HTTP GET request when the corresponding state is
+# reached, and any state you leave out is simply not reported.
+monitor:
+  start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
+  success: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=ok
+  failure: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=error
+
 backups:
   # Backup all the repositories that the provided credentials have access to
   - kind: github/repo

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -4,7 +4,7 @@ schedule: "0 * * * *"
 # monitoring service (such as Sentry Crons or healthchecks.io). Each URL is
 # fetched with a simple HTTP GET request when the corresponding state is
 # reached, and any state you leave out is simply not reported.
-monitor:
+ping:
   start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
   success: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=ok
   failure: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=error

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use human_errors::ResultExt;
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
 
-use crate::{Args, monitor::MonitorConfig, policy::BackupPolicy};
+use crate::{Args, ping::PingConfig, policy::BackupPolicy};
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -10,7 +10,7 @@ pub struct Config {
     pub schedule: Option<croner::Cron>,
 
     #[serde(default)]
-    pub monitor: MonitorConfig,
+    pub ping: PingConfig,
 
     #[serde(default)]
     pub backups: Vec<BackupPolicy>,
@@ -67,16 +67,16 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_monitor_not_provided() {
+    fn deserialize_ping_not_provided() {
         let config: Config = serde_yaml::from_str("").unwrap();
-        assert_eq!(config.monitor, crate::monitor::MonitorConfig::default());
+        assert_eq!(config.ping, crate::ping::PingConfig::default());
     }
 
     #[test]
-    fn deserialize_monitor() {
+    fn deserialize_ping() {
         let config: Config = serde_yaml::from_str(
             r#"
-            monitor:
+            ping:
               start: https://example.com/start
               success: https://example.com/success
               failure: https://example.com/failure
@@ -85,15 +85,15 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            config.monitor.start.as_deref(),
+            config.ping.start.as_deref(),
             Some("https://example.com/start")
         );
         assert_eq!(
-            config.monitor.success.as_deref(),
+            config.ping.success.as_deref(),
             Some("https://example.com/success")
         );
         assert_eq!(
-            config.monitor.failure.as_deref(),
+            config.ping.failure.as_deref(),
             Some("https://example.com/failure")
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,15 @@ use human_errors::ResultExt;
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
 
-use crate::{Args, policy::BackupPolicy};
+use crate::{Args, monitor::MonitorConfig, policy::BackupPolicy};
 
 #[derive(Deserialize)]
 pub struct Config {
     #[serde(default, deserialize_with = "deserialize_cron")]
     pub schedule: Option<croner::Cron>,
+
+    #[serde(default)]
+    pub monitor: MonitorConfig,
 
     #[serde(default)]
     pub backups: Vec<BackupPolicy>,
@@ -61,6 +64,38 @@ mod tests {
     fn deserialize_cron_not_provided() {
         let config: Config = serde_yaml::from_str("").unwrap();
         assert!(config.schedule.is_none());
+    }
+
+    #[test]
+    fn deserialize_monitor_not_provided() {
+        let config: Config = serde_yaml::from_str("").unwrap();
+        assert_eq!(config.monitor, crate::monitor::MonitorConfig::default());
+    }
+
+    #[test]
+    fn deserialize_monitor() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+            monitor:
+              start: https://example.com/start
+              success: https://example.com/success
+              failure: https://example.com/failure
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.monitor.start.as_deref(),
+            Some("https://example.com/start")
+        );
+        assert_eq!(
+            config.monitor.success.as_deref(),
+            Some("https://example.com/success")
+        );
+        assert_eq!(
+            config.monitor.failure.as_deref(),
+            Some("https://example.com/failure")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use engines::BackupState;
 use human_errors::Error;
-use monitor::Monitor;
 use pairing::PairingHandler;
+use ping::Pinger;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 use tracing_batteries::prelude::*;
@@ -16,8 +16,8 @@ mod engines;
 mod entities;
 mod errors;
 pub(crate) mod helpers;
-mod monitor;
 mod pairing;
+mod ping;
 mod policy;
 mod sources;
 mod target;
@@ -53,7 +53,7 @@ pub struct Args {
 async fn run(args: Args, session: &Session) -> Result<(), Error> {
     let config = config::Config::try_from(&args)?;
 
-    let monitor = Monitor::new(config.monitor.clone());
+    let pinger = Pinger::new(config.ping.clone());
 
     let github_repo = pairing::Pairing::new(
         sources::GitHubRepoSource::default(),
@@ -84,7 +84,7 @@ async fn run(args: Args, session: &Session) -> Result<(), Error> {
 
         let handler = LoggingPairingHandler::default();
 
-        monitor.on_start().await;
+        pinger.on_start().await;
 
         {
             let _span = info_span!("backup.all").entered();
@@ -120,9 +120,9 @@ async fn run(args: Args, session: &Session) -> Result<(), Error> {
         }
 
         if handler.errors() > 0 {
-            monitor.on_failure().await;
+            pinger.on_failure().await;
         } else {
-            monitor.on_success().await;
+            pinger.on_success().await;
         }
 
         if let Some(next_run) = next_run {
@@ -208,5 +208,28 @@ async fn main() {
         std::process::exit(1);
     } else {
         session.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::GitRepo;
+
+    #[test]
+    fn logging_handler_counts_errors() {
+        let handler = LoggingPairingHandler::default();
+        assert_eq!(handler.errors(), 0);
+
+        // Each reported error should be accumulated so that a run with any
+        // failures can be reported to the cron monitor as a failure.
+        PairingHandler::<GitRepo>::on_error(&handler, human_errors::user("boom", &[]));
+        PairingHandler::<GitRepo>::on_error(&handler, human_errors::user("boom", &[]));
+        assert_eq!(handler.errors(), 2);
+
+        // Successful completions must not affect the error count.
+        let repo = GitRepo::new("octocat/Hello-World", "https://example.com/repo.git", None);
+        handler.on_complete(repo, BackupState::Skipped);
+        assert_eq!(handler.errors(), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use clap::Parser;
 use engines::BackupState;
 use human_errors::Error;
+use monitor::Monitor;
 use pairing::PairingHandler;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 use tracing_batteries::prelude::*;
 use tracing_batteries::{OpenTelemetry, Session, Umami};
@@ -15,6 +16,7 @@ mod engines;
 mod entities;
 mod errors;
 pub(crate) mod helpers;
+mod monitor;
 mod pairing;
 mod policy;
 mod sources;
@@ -51,6 +53,8 @@ pub struct Args {
 async fn run(args: Args, session: &Session) -> Result<(), Error> {
     let config = config::Config::try_from(&args)?;
 
+    let monitor = Monitor::new(config.monitor.clone());
+
     let github_repo = pairing::Pairing::new(
         sources::GitHubRepoSource::default(),
         engines::RepoEngine::new(),
@@ -78,6 +82,10 @@ async fn run(args: Args, session: &Session) -> Result<(), Error> {
             .as_ref()
             .and_then(|s| s.find_next_occurrence(&chrono::Utc::now(), false).ok());
 
+        let handler = LoggingPairingHandler::default();
+
+        monitor.on_start().await;
+
         {
             let _span = info_span!("backup.all").entered();
 
@@ -88,21 +96,15 @@ async fn run(args: Args, session: &Session) -> Result<(), Error> {
                 match policy.kind.as_str() {
                     k if k == GitHubArtifactKind::Repo.as_str() => {
                         info!("Backing up repositories for {}", &policy);
-                        github_repo
-                            .run(policy, &LoggingPairingHandler, &CANCEL)
-                            .await;
+                        github_repo.run(policy, &handler, &CANCEL).await;
                     }
                     k if k == GitHubArtifactKind::Release.as_str() => {
                         info!("Backing up release artifacts for {}", &policy);
-                        github_release
-                            .run(policy, &LoggingPairingHandler, &CANCEL)
-                            .await;
+                        github_release.run(policy, &handler, &CANCEL).await;
                     }
                     k if k == GitHubArtifactKind::Gist.as_str() => {
                         info!("Backing up gist artifacts for {}", &policy);
-                        github_gist
-                            .run(policy, &LoggingPairingHandler, &CANCEL)
-                            .await;
+                        github_gist.run(policy, &handler, &CANCEL).await;
                     }
                     _ => {
                         error!("Unknown policy kind: {}", policy.kind);
@@ -112,7 +114,15 @@ async fn run(args: Args, session: &Session) -> Result<(), Error> {
         }
 
         if CANCEL.load(std::sync::atomic::Ordering::Relaxed) {
+            // The run was interrupted (e.g. by SIGINT), so we deliberately avoid
+            // reporting either success or failure to the cron monitor.
             break;
+        }
+
+        if handler.errors() > 0 {
+            monitor.on_failure().await;
+        } else {
+            monitor.on_success().await;
         }
 
         if let Some(next_run) = next_run {
@@ -131,7 +141,19 @@ async fn run(args: Args, session: &Session) -> Result<(), Error> {
     Ok(())
 }
 
-pub struct LoggingPairingHandler;
+#[derive(Default)]
+pub struct LoggingPairingHandler {
+    errors: AtomicUsize,
+}
+
+impl LoggingPairingHandler {
+    /// The total number of errors observed across every policy reported to this
+    /// handler, used to decide whether a backup run should be reported as a
+    /// success or a failure to the cron monitor.
+    fn errors(&self) -> usize {
+        self.errors.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
 
 impl<E: BackupEntity> PairingHandler<E> for LoggingPairingHandler {
     fn on_complete(&self, entity: E, state: BackupState) {
@@ -144,6 +166,8 @@ impl<E: BackupEntity> PairingHandler<E> for LoggingPairingHandler {
     }
 
     fn on_error(&self, error: Error) {
+        self.errors
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         warn!("Error: {}", error);
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,0 +1,176 @@
+use serde::Deserialize;
+use tracing_batteries::prelude::*;
+
+/// Configuration for an HTTP-based cron monitoring solution (such as
+/// [Sentry Cron Monitors](https://docs.sentry.io/product/crons/) or
+/// [healthchecks.io](https://healthchecks.io)).
+///
+/// Each field holds an optional URL which will be fetched (via an HTTP `GET`
+/// request) when the corresponding state is reached during a scheduled backup
+/// run. Any field which is left unset is simply skipped, allowing you to report
+/// only the states you care about.
+#[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq)]
+pub struct MonitorConfig {
+    /// The URL to fetch when a backup run starts.
+    #[serde(default)]
+    pub start: Option<String>,
+
+    /// The URL to fetch when a backup run completes successfully.
+    #[serde(default)]
+    pub success: Option<String>,
+
+    /// The URL to fetch when a backup run completes with one or more errors.
+    #[serde(default)]
+    pub failure: Option<String>,
+}
+
+/// Reports the lifecycle of a backup run to an HTTP-based cron monitoring
+/// service by issuing simple `GET` requests to the URLs configured in
+/// [`MonitorConfig`].
+///
+/// Reporting is best-effort: failures to reach the monitoring service are
+/// logged but never propagated, ensuring that a flaky monitor can never cause
+/// an otherwise healthy backup run to be reported as failed.
+pub struct Monitor {
+    config: MonitorConfig,
+    client: reqwest::Client,
+}
+
+impl Monitor {
+    pub fn new(config: MonitorConfig) -> Self {
+        Self {
+            config,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Report that a backup run has started.
+    pub async fn on_start(&self) {
+        self.ping("start", self.config.start.as_deref()).await;
+    }
+
+    /// Report that a backup run has completed successfully.
+    pub async fn on_success(&self) {
+        self.ping("success", self.config.success.as_deref()).await;
+    }
+
+    /// Report that a backup run has completed with one or more errors.
+    pub async fn on_failure(&self) {
+        self.ping("failure", self.config.failure.as_deref()).await;
+    }
+
+    #[tracing::instrument(skip(self, url), fields(monitor.state = state))]
+    async fn ping(&self, state: &str, url: Option<&str>) {
+        let Some(url) = url else {
+            return;
+        };
+
+        debug!("Reporting '{state}' state to cron monitor.");
+
+        match self
+            .client
+            .get(url)
+            .header("User-Agent", "SierraSoftworks/github-backup")
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                debug!("Successfully reported '{state}' state to cron monitor.");
+            }
+            Ok(resp) => {
+                warn!(
+                    "Cron monitor returned HTTP {} when reporting the '{state}' state.",
+                    resp.status()
+                );
+            }
+            Err(e) => {
+                warn!("Failed to report the '{state}' state to the cron monitor: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn deserialize_empty() {
+        let config: MonitorConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(config, MonitorConfig::default());
+    }
+
+    #[test]
+    fn deserialize_partial() {
+        let config: MonitorConfig =
+            serde_yaml::from_str("start: https://example.com/start").unwrap();
+        assert_eq!(config.start.as_deref(), Some("https://example.com/start"));
+        assert_eq!(config.success, None);
+        assert_eq!(config.failure, None);
+    }
+
+    #[tokio::test]
+    async fn reports_each_state() {
+        let server = MockServer::start().await;
+
+        for state in ["start", "success", "failure"] {
+            Mock::given(method("GET"))
+                .and(path(format!("/{state}")))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+
+        let monitor = Monitor::new(MonitorConfig {
+            start: Some(format!("{}/start", server.uri())),
+            success: Some(format!("{}/success", server.uri())),
+            failure: Some(format!("{}/failure", server.uri())),
+        });
+
+        monitor.on_start().await;
+        monitor.on_success().await;
+        monitor.on_failure().await;
+
+        // `MockServer` verifies the `.expect(1)` expectations when dropped.
+    }
+
+    #[tokio::test]
+    async fn unconfigured_states_make_no_request() {
+        let server = MockServer::start().await;
+
+        // Any request reaching the server would fail the `expect(0)` guard.
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let monitor = Monitor::new(MonitorConfig::default());
+
+        monitor.on_start().await;
+        monitor.on_success().await;
+        monitor.on_failure().await;
+    }
+
+    #[tokio::test]
+    async fn error_responses_are_swallowed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let monitor = Monitor::new(MonitorConfig {
+            success: Some(format!("{}/success", server.uri())),
+            ..Default::default()
+        });
+
+        // This must not panic even though the monitor returned an error status.
+        monitor.on_success().await;
+    }
+}

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -10,7 +10,7 @@ use tracing_batteries::prelude::*;
 /// run. Any field which is left unset is simply skipped, allowing you to report
 /// only the states you care about.
 #[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq)]
-pub struct MonitorConfig {
+pub struct PingConfig {
     /// The URL to fetch when a backup run starts.
     #[serde(default)]
     pub start: Option<String>,
@@ -26,18 +26,18 @@ pub struct MonitorConfig {
 
 /// Reports the lifecycle of a backup run to an HTTP-based cron monitoring
 /// service by issuing simple `GET` requests to the URLs configured in
-/// [`MonitorConfig`].
+/// [`PingConfig`].
 ///
 /// Reporting is best-effort: failures to reach the monitoring service are
 /// logged but never propagated, ensuring that a flaky monitor can never cause
 /// an otherwise healthy backup run to be reported as failed.
-pub struct Monitor {
-    config: MonitorConfig,
+pub struct Pinger {
+    config: PingConfig,
     client: reqwest::Client,
 }
 
-impl Monitor {
-    pub fn new(config: MonitorConfig) -> Self {
+impl Pinger {
+    pub fn new(config: PingConfig) -> Self {
         Self {
             config,
             client: reqwest::Client::new(),
@@ -59,7 +59,7 @@ impl Monitor {
         self.ping("failure", self.config.failure.as_deref()).await;
     }
 
-    #[tracing::instrument(skip(self, url), fields(monitor.state = state))]
+    #[tracing::instrument(skip(self, url), fields(ping.state = state))]
     async fn ping(&self, state: &str, url: Option<&str>) {
         let Some(url) = url else {
             return;
@@ -98,14 +98,13 @@ mod tests {
 
     #[test]
     fn deserialize_empty() {
-        let config: MonitorConfig = serde_yaml::from_str("{}").unwrap();
-        assert_eq!(config, MonitorConfig::default());
+        let config: PingConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(config, PingConfig::default());
     }
 
     #[test]
     fn deserialize_partial() {
-        let config: MonitorConfig =
-            serde_yaml::from_str("start: https://example.com/start").unwrap();
+        let config: PingConfig = serde_yaml::from_str("start: https://example.com/start").unwrap();
         assert_eq!(config.start.as_deref(), Some("https://example.com/start"));
         assert_eq!(config.success, None);
         assert_eq!(config.failure, None);
@@ -124,15 +123,15 @@ mod tests {
                 .await;
         }
 
-        let monitor = Monitor::new(MonitorConfig {
+        let pinger = Pinger::new(PingConfig {
             start: Some(format!("{}/start", server.uri())),
             success: Some(format!("{}/success", server.uri())),
             failure: Some(format!("{}/failure", server.uri())),
         });
 
-        monitor.on_start().await;
-        monitor.on_success().await;
-        monitor.on_failure().await;
+        pinger.on_start().await;
+        pinger.on_success().await;
+        pinger.on_failure().await;
 
         // `MockServer` verifies the `.expect(1)` expectations when dropped.
     }
@@ -148,11 +147,11 @@ mod tests {
             .mount(&server)
             .await;
 
-        let monitor = Monitor::new(MonitorConfig::default());
+        let pinger = Pinger::new(PingConfig::default());
 
-        monitor.on_start().await;
-        monitor.on_success().await;
-        monitor.on_failure().await;
+        pinger.on_start().await;
+        pinger.on_success().await;
+        pinger.on_failure().await;
     }
 
     #[tokio::test]
@@ -165,12 +164,12 @@ mod tests {
             .mount(&server)
             .await;
 
-        let monitor = Monitor::new(MonitorConfig {
+        let pinger = Pinger::new(PingConfig {
             success: Some(format!("{}/success", server.uri())),
             ..Default::default()
         });
 
         // This must not panic even though the monitor returned an error status.
-        monitor.on_success().await;
+        pinger.on_success().await;
     }
 }


### PR DESCRIPTION
## Summary

Adds support for reporting the lifecycle of each scheduled backup run to an HTTP-based cron monitoring service (such as [Sentry Cron Monitors](https://docs.sentry.io/product/crons/getting-started/http/) or [healthchecks.io](https://healthchecks.io/)), as requested.

The application makes a simple HTTP `GET` request to a configured endpoint whenever a scheduled run **starts** and again when it **completes** — reporting **success** if every policy ran cleanly and **failure** if any policy produced one or more errors.

## Configuration

A new top-level `ping` key accepts an optional URL for each state. Any state you leave out is simply not reported:

```yaml
schedule: "0 * * * *"

ping:
  start: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=in_progress
  success: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=ok
  failure: https://sentry.io/api/0/organizations/your-org/monitors/github-backup/checkins/?status=error

backups:
  - kind: github/repo
    from: user
    to: /backup/github
    credentials: !Token your_access_token
```

Allowing a separate URL per state keeps the implementation to plain `GET` requests while supporting both query-parameter-based services (Sentry: `?status=...`) and path-suffix-based services (healthchecks.io: `/start`, `/fail`).

## Behaviour notes

- **Best-effort.** If the monitoring service can't be reached (or returns a non-2xx status), a warning is logged but the backup run itself is never affected. A flaky monitor can't cause an otherwise healthy run to be reported as failed.
- **Interrupted runs.** If a run is interrupted via `SIGINT`, neither `success` nor `failure` is reported (the monitor will naturally observe a missed check-in).
- A run is reported as `failure` when any policy reports one or more errors, tracked via the pairing handler's error count.

## Implementation

- New `src/ping.rs` module with `PingConfig` (deserialized from the `ping` key) and a `Pinger` that issues the `GET` requests.
- `Config` gains a `ping` field.
- `main.rs` instantiates the pinger and reports `start` before each run and `success`/`failure` afterwards; `LoggingPairingHandler` now accumulates an error count to drive that decision.

## Testing

- Unit tests for `PingConfig` deserialization.
- `wiremock`-backed tests verifying each state hits the right URL, that unconfigured states make no request, and that error responses are swallowed without panicking.
- Config tests covering the new `ping` section (present and absent).
- A unit test for `LoggingPairingHandler`'s error counting (the success/failure decision logic).

`cargo clippy` and `cargo test --features pure_tests` both pass cleanly. (The repository's network-dependent GitHub API tests fail in the sandbox due to no outbound access, unrelated to this change; they are gated by the `pure_tests` feature.)

## Docs

- New "Cron Monitoring" section in the README.
- New `docs/guide/monitors.md` guide page (added to the VuePress sidebar) with Sentry and healthchecks.io examples.
- Example added to `examples/config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)