### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ GitHub organizations and clone (or fetch) them to your local machine. It is desi
 as part of a scheduled backup process with the ultimate goal of ensuring that you have a local
 copy of all of your GitHub repositories should the unthinkable happen.
 
+## Installation
+
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/github-backup
+```
+
 ## Features
 
 - **Backup Multiple Organizations**, automatically gathering the full list of repositories for

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -14,6 +14,14 @@ To solve this, we created GitHub Backup - a lightweight tool which runs a schedu
 backup/sync of your GitHub repositories with advanced filtering support to ensure that
 only the repositories you care about are backed up.
 
+## Installation
+On macOS and Linux, the easiest way to get started is to install GitHub Backup
+from the Sierra Softworks [Homebrew](https://brew.sh) tap.
+
+```sh
+brew install sierrasoftworks/tap/github-backup
+```
+
 ## Example
 To run GitHub Backup, you will need to download the latest release from the
 [GitHub Releases](https://github.com/SierraSoftworks/github-backup/releases)


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README and documentation site, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/github-backup

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
