### PR TITLE
Replace Umami analytics with the new Analytics battery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4403,10 +4403,11 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#89854ad16dde3c4af6b9fc6e87ffa0d64b158fc1"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#cf35de7fad4e013391383219abed2f4d58abe963"
 dependencies = [
  "chrono",
  "hex",
+ "iana-time-zone",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tokio = { version = "1.50.0", features = [
 ] }
 tokio-stream = "0.1.18"
 tracing = "0.1.44"
-tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batteries-rs.git", features = ["umami", "opentelemetry", "sentry"] }
+tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batteries-rs.git", features = ["analytics", "opentelemetry", "sentry"] }
 unicase = "2.9.0"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use ping::Pinger;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 use tracing_batteries::prelude::*;
-use tracing_batteries::{OpenTelemetry, Session, Umami};
+use tracing_batteries::{Analytics, OpenTelemetry, Session};
 
 #[macro_use]
 mod macros;
@@ -191,13 +191,7 @@ async fn main() {
 
     let session = Session::new("github-backup", version!())
         .with_battery(OpenTelemetry::new(""))
-        .with_battery(
-            Umami::new(
-                "https://analytics.sierrasoftworks.com",
-                "0b7b161d-5120-44da-930c-bac4999e2fca",
-            )
-            .with_initial_page("/.app/"),
-        );
+        .with_battery(Analytics::new("https://analytics.sierrasoftworks.com"));
 
     let result = run(args, &session).await;
 


### PR DESCRIPTION
## Summary

Umami analytics is being retired in favor of the new self-hosted analytics server at https://analytics.sierrasoftworks.com. This PR migrates `github-backup` to the `tracing-batteries` `Analytics` battery, which replaces the old `Umami` battery.

- Swapped the `tracing-batteries` cargo feature flag from `umami` to `analytics` in `Cargo.toml`.
- Replaced `Umami::new(server_url, website_id).with_initial_page("/.app/")` with `Analytics::new(server_url)`. The new battery takes only the server URL (no website ID) and no longer needs the `/.app/` page-prefix convention — it defaults to page `/` on a virtual hostname of `{service}.app`.
- Updated the `use tracing_batteries::{...}` import accordingly.
- Bumped `Cargo.lock` via `cargo update tracing-batteries` to pull in the latest `main` of the `tracing-batteries-rs` git dependency, which ships the `Analytics` battery.

No changes were needed to the existing `session.record_new_page(format!("/backup/{}", policy))` call — it already uses a clean path.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `cargo test` — 111 passed; 6 pre-existing failures unrelated to this change (network/TLS errors reaching `api.github.com` from the sandbox, in GitHub API test helpers, not the analytics code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NutKW958x2VF9rVagycenv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NutKW958x2VF9rVagycenv)_