### PR TITLE
Update tracing-batteries to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4403,7 +4403,7 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#cf35de7fad4e013391383219abed2f4d58abe963"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#e1f168e57bb74c146405cf74d6120902fe677926"
 dependencies = [
  "chrono",
  "hex",


### PR DESCRIPTION
Bumps the `tracing-batteries` git dependency pin in `Cargo.lock` to the latest commit on its main branch.

- Old pin: `cf35de7fad4e013391383219abed2f4d58abe963`
- New pin: `e1f168e57bb74c146405cf74d6120902fe677926`

## Verification
- `cargo check --workspace`: passes cleanly.
- `cargo test --workspace`: 111 passed, 6 failed. The 6 failures (`helpers::github::tests::{fetch_gist,fetch_repos,get_repo}`, `sources::github_releases::tests::get_releases`, `sources::github_repo::tests::get_repos`) are pre-existing/environmental — they fail because the sandbox cannot make TLS connections to `api.github.com` (`InvalidCertificate(UnknownIssuer)`), unrelated to this dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NutKW958x2VF9rVagycenv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NutKW958x2VF9rVagycenv)_