### PR TITLE
build(ci): Build linux-arm64 on GitHub's native arm64 runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,6 @@ jobs:
             run_on: windows-latest
             target: x86_64-pc-windows-msvc
             extension: .exe
-            builder: cargo
 
           # Linux builds
           - arch: amd64
@@ -115,24 +114,20 @@ jobs:
             os: linux
             target: x86_64-unknown-linux-gnu
             test: true
-            builder: cargo
           - arch: "arm64"
             os: linux
-            run_on: ubuntu-latest
+            run_on: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            builder: cross
 
           # Apple MacOS builds
           - arch: amd64
             run_on: macos-latest
             os: darwin
             target: x86_64-apple-darwin
-            builder: cargo
           - arch: arm64
             run_on: macos-latest
             os: darwin
             target: aarch64-apple-darwin
-            builder: cargo
 
     steps:
       - name: Check out code
@@ -145,20 +140,6 @@ jobs:
           target: ${{ matrix.target }}
           components: llvm-tools-preview
 
-      # Install cross *before* Setup Cache. rust-cache restores cargo's
-      # install metadata (.crates2.json) but not the cargo bin directory,
-      # so if the cache runs first, binstall sees cross as "already
-      # installed", skips it, and the binary is never materialised. Running
-      # the install against a clean CARGO_HOME (with --force) guarantees the
-      # binary actually exists.
-      - name: Install Cross
-        if: matrix.builder == 'cross'
-        shell: bash
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm --force cross
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
-
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -170,7 +151,7 @@ jobs:
           name: cargofile
 
       - name: cargo build
-        run: ${{ matrix.builder }} build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload GitHub Release Artifacts
         uses: SierraSoftworks/gh-releases@v1.0.10


### PR DESCRIPTION
Switches the `linux-arm64` build from `cross` to GitHub's [native arm64 runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) (`ubuntu-24.04-arm`, free for public repositories).

## What changed

- `build` matrix: the arm64 Linux entry now runs on `ubuntu-24.04-arm` and builds `aarch64-unknown-linux-gnu` natively.
- Removed the cargo-binstall/`cross` install step, along with the comment documenting why it had to be ordered before the cache restore (binstall would otherwise see cross as installed and skip materialising the binary).
- With every entry now building with `cargo`, the `builder` matrix key is gone.

No extra setup is needed for the target: the dependency graph is pure Rust apart from aws-lc-sys, which builds against the runner's own toolchain the same way it does on the amd64 entry.

## Why

The arm64 build was the only reason the workflow installed `cross` at all, and keeping that install correct required careful ordering against `Swatinem/rust-cache`. On a native arm64 runner the target builds with exactly the same steps as every other entry in the matrix.

## Verification

CI on this PR builds `linux-arm64` on the native runner; the release-only steps (artifact upload, Docker packaging) are unchanged and consume the same artifact name as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMWNbMN9txD8wr3uT9W1TJ)_